### PR TITLE
added click handler for presets buttons

### DIFF
--- a/src/components/DateRangePicker.vue
+++ b/src/components/DateRangePicker.vue
@@ -8,8 +8,8 @@
         ) {{ $legends[locale].panels[panel] }}
 
     .preset-ranges(v-if="isPresetPicker && presets.length > 1")
-      .preset(v-for="entry in availablePresets")
-        input(type="radio" v-model="preset" :id="entry" :value="entry")
+      .preset(v-for="entry in availablePresets" @click="selectPreset(entry)")
+        input(type="radio" v-model="preset" :value="entry")
         label(:for="entry")
           span.check
           span {{ $legends[locale].presets[entry] }}
@@ -524,6 +524,10 @@ export default class extends Vue {
   changeYear(diff: number) {
     this.current = subYears(this.current, diff)
     this.updateCalendar()
+  }
+
+  selectPreset(preset) {
+    this.preset = preset
   }
 
   selectDay(date) {


### PR DESCRIPTION
#11

Looks like pug has some problem binding v-model with radio inputs, because it only works if you provide "id" on inputs, but then it behaves buggy.
Adding a click handler on the preset div makes this work properly with multiple instances of vue-mj-daterangepicker.